### PR TITLE
Add basic test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes credentials package.json",
     "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "npm build && npm lint -c .eslintrc.prepublish.js nodes credentials package.json"
+    "prepublishOnly": "npm build && npm lint -c .eslintrc.prepublish.js nodes credentials package.json",
+    "test": "node --test"
   },
   "files": [
     "dist"

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)));
+
+test('package name is defined', () => {
+  assert.ok(pkg.name && pkg.name.length > 0);
+});


### PR DESCRIPTION
## Summary
- configure npm test script to use Node's built-in runner
- add a basic package.json test

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: EHOSTUNREACH when trying to fetch rimraf)*